### PR TITLE
Added new functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Google2Pandas will eventually be a set of tools that will allow for easy queryin
 of various google database products (Analytics, BigQuery, etc.) with the results
 returned as pandas.DataFrame objects (http://pandas.pydata.org/).
 
-At this point, only queries to Google Analytics via the core reporting API are
-supported.
+At this point, only queries to Google Analytics and the Multi-Channel Funnels Reporting via
++the core reporting API are supported.
 
 ##Nomenclature##
 Suggested usage: 
@@ -46,5 +46,5 @@ query = {\
     'max_results'   : 10}
     
 ga = GoogleAnalyticsQuery(token_file_name='analytics.dat')
-df, formatted_qry = ga.execute_query(**query)
+df, metadata = ga.execute_query(**query)
 ```

--- a/google2pandas/__init__.py
+++ b/google2pandas/__init__.py
@@ -5,5 +5,5 @@ Keywords: google analytics, pandas
 '''
 
 # bring classes directly into package namespace
-from ._panalysis_ga import GoogleAnalyticsQuery
+from ._panalysis_ga import GoogleAnalyticsQuery, GoogleMCFQuery
 

--- a/google2pandas/_panalysis_ga.py
+++ b/google2pandas/_panalysis_ga.py
@@ -6,7 +6,10 @@ from googleapiclient.discovery import build
 from oauth2client import client, file, tools
 
 import pandas as pd
+import numpy as np
 import httplib2, os
+
+from _query_parser import QueryParser
 
 no_callback = client.OOB_CALLBACK_URN
 default_scope = 'https://www.googleapis.com/auth/analytics.readonly'
@@ -80,6 +83,15 @@ class OAuthDataReader(object):
         
         return flow
     
+    def _init_service(self, secrets):
+        '''
+        Build an authenticated google api request service using the given
+        secrets file
+        '''
+        http = self._authenticate(secrets)
+        
+        return build('analytics', 'v3', http=http)
+    
     def _reset_default_token_store(self):
         os.remove(default_token_file)
     
@@ -104,13 +116,13 @@ class GoogleAnalyticsQuery(OAuthDataReader):
         super(GoogleAnalyticsQuery, self).__init__(scope, token_file_name, redirect)
         self._service = self._init_service(secrets)
         
-    def execute_query(self, provide_json=False, **query):
+    def execute_query(self, as_dict=False, **query):
         '''
         Execute **query and translate it to a pandas.DataFrame object.
         
         Parameters:
         -----------
-            provide_json : Boolean
+            as_dict : Boolean
                 return the dict object provided by GA instead of the DataFrame
                 object. Default = False
             query : dict.
@@ -159,7 +171,7 @@ class GoogleAnalyticsQuery(OAuthDataReader):
             output      str     N       The desired output type for the Analytics data returned
                                         in the response. Acceptable values are 'json' and 
                                         'dataTable'. Default is 'json'; if this option is
-                                        used the 'provide_json' keyword argument is set
+                                        used the 'as_dict' keyword argument is set
                                         to True and a dict object is returned.
             fields      list    N       Selector specifying a subset of fields to include in 
                                         the response.
@@ -178,13 +190,15 @@ class GoogleAnalyticsQuery(OAuthDataReader):
         Returns:
         -----------
             reuslt : pd.DataFrame or dict
+            query  : a copy of the (formatted) query actually used
+            sampling : summay of sampling data if result contains sampled data
         '''
         try:
-            formatted_query = self._format_query(**query)
+            formatted_query = QueryParser().parse(**query)
             
             try:
                 if formatted_query['output']:
-                    provide_json = True
+                    as_dict = True
                     
             except KeyError as e:
                 pass
@@ -196,8 +210,8 @@ class GoogleAnalyticsQuery(OAuthDataReader):
         
         res = ga_query.execute()
         
-        if provide_json:
-            return res, formatted_query
+        if as_dict:
+            return res
         
         else:
             # re-cast query result (dict) to a pd.DataFrame object
@@ -229,194 +243,144 @@ class GoogleAnalyticsQuery(OAuthDataReader):
                 
                 df[col] = df[col].apply(my_mapper(dtp))
                 
-            return df, formatted_query
+            # Get the summary info returned
+            metadata = res.copy()
+            metadata.pop('rows')
+            metadata.pop('columnHeaders')
+                
+            return df, metadata
         
-    def _init_service(self, secrets):
+        
+class GoogleMCFQuery(OAuthDataReader):
+    def __init__(self, scope=default_scope, token_file_name=default_token_file,
+                 redirect=no_callback, secrets=default_secrets):
         '''
-        Build an authenticated google api request service using the given
-        secrets file
+        Query the MCF API with ease!  Simply obtain the 'client_secrets.json' file
+        as usual and move it to the same directory as this file (default) or
+        specify the file location when instantiating this class.
+        
+        If one does not exist, an 'analytics.dat' token file will also be
+        created / read from the current working directory or whatever has 
+        imported the class (default) or, one may specify the desired
+        location when instantiating this class.  Note that this file requires
+        write access, so you may need to either adjust the file permissions if
+        using the default value.
+        
+        API queries must be provided as a dict. object, see the execute_query
+        docstring for valid options.
         '''
-        http = self._authenticate(secrets)
+        super(GoogleMCFQuery, self).__init__(scope, token_file_name, redirect)
+        self._service = self._init_service(secrets)
         
-        return build('analytics', 'v3', http=http)
-        
-    def _format_query(self, **kwargs):
+    def execute_query(self, as_dict=False, **query):
         '''
-        Check query structure to ensure formatting is valid
+        Execute **query and translate it to a pandas.DataFrame object.
+        
+        Parameters:
+        -----------
+            as_dict : Boolean
+                return the dict object provided by MCF instead of the DataFrame
+                object. Default = False
+            query : dict.
+                MCF query, only with some added flexibility to be a bit sloppy. Adapted from
+                https://developers.google.com/analytics/devguides/reporting/mcf/v3/reference
+                The valid keys are:
+                
+            Key         Value   Reqd.   Summary
+            --------------------------------------------------------------------------------
+            ids         int     Y       The unique table ID of the form ga:XXXX or simply
+                                        XXXX, where XXXX is the Analytics view (profile)
+                                        ID for which the  query will retrieve the data.
+            start_date  str     Y       Start date for fetching Analytics data. Requests can
+                                        specify a start date formatted as YYYY-MM-DD, or as
+                                        a relative date (e.g., today, yesterday, or NdaysAgo
+                                        where N is a positive integer).
+            end_date    str     Y       End date for fetching Analytics data. Request can 
+                                        specify an end date formatted as YYYY-MM-DD, or as
+                                        a relative date (e.g., today, yesterday, or NdaysAgo
+                                        where N is a positive integer).
+            metrics     list    Y       A list of comma-separated metrics, such as 
+                                        'ga:sessions', 'ga:bounces', or simply 'sessions', etc.
+            dimensions  list    N       A list of comma-separated dimensions for your
+                                        Analytics data, such as 'ga:browser', 'ga:city',
+                                        or simply 'browser', etc.
+            sort        list    N       A list of comma-separated dimensions and metrics
+                                        indicating the sorting order and sorting direction
+                                        for the returned data.
+            filters     list    N       Dimension or metric filters that restrict the data
+                                        returned for your request. Multiple filters must
+                                        be connected with 'and' or 'or' entries, with no
+                                        default behaviour prescribed.
+            samplingLevel str   N       The desired sampling level. Allowed Values:
+                                        'DEFAULT' - Returns response with a sample size that
+                                                    balances speed and accuracy.
+                                        'FASTER' -  Returns a fast response with a smaller
+                                                    sample size.
+                                        'HIGHER_PRECISION' - Returns a more accurate response
+                                                    using a large sample size, but this may 
+                                                    result in the response being slower.
+            start_index int     N       The first row of data to retrieve, starting at 1.
+                                        Use this parameter as a pagination mechanism along
+                                        with the max-results parameter.
+            max_results int     N       The maximum number of rows to include in the response.
+                
+        Returns:
+        -----------
+            reuslt : pd.DataFrame or dict
+            query  : a copy of the (formatted) query actually used
+            sampling : summay of sampling data if result contains sampled data
         '''
-        query = {}
-        query.update(kwargs)
-        
-        # 1. Dates
-        # The next two steps keep things consistent if the query is to be archived.
         try:
-            if query['start_date'][-7:] == 'daysAgo':
-                sd = pd.datetime.today() + \
-                    pd.tseries.offsets.DateOffset(days=-int(query['start_date'][:-7]))
-                query['start_date'] = sd.strftime('%Y-%m-%d')
-                
-            elif query['start_date'] == 'yesterday':
-                sd = pd.datetime.today() + pd.tseries.offsets.DateOffset(days=-1)
-                query['start_date'] = sd.strftime('%Y-%m-%d')
-                
-            elif query['start_date'] == 'today':
-                query['start_date'] = pd.datetime.today().strftime('%Y-%m-%d')
-                
-            else:
-                query['start_date'] = pd.to_datetime(query['start_date'], \
-                    format='%Y-%m-%d').strftime('%Y-%m-%d')
-                
-        except (KeyError, AttributeError) as e:
-            raise ValueError('The (required) \'start_date\' parameter is missing or invalid')
+            formatted_query = QueryParser(prefix=u'mcf:').parse(**query)
             
-        try:
-            if (query['end_date'] is None) | (query['end_date'] == 'today'):
-                end_date = pd.datetime.today().strftime('%Y-%m-%d')
-                
-            else:
-                query['end_date'] = pd.to_datetime(query['end_date']).strftime('%Y-%m-%d')
-                
-        except KeyError:
-            query['end_date'] = pd.datetime.today().strftime('%Y-%m-%d')
-        
-        # 2. 'ga:' prefixing
-        # Ensure that all fields that should be in the form 'ga:XXXX' acutally are.
-        # Error handling skipped at this location intentionally.
-        #
-        # First sneak in fix to allow providing ids as int value
-        query['ids'] = str(query['ids'])
-        
-        names = 'ids', 'dimensions', 'metrics'
-        lst = query['ids'], query['dimensions'], query['metrics']
-        [self._maybe_add_arg(query, n, d) for n, d in zip(names, lst)]
-        
-        # 3. Clean up the filtering if present
-        try:
-            [self._maybe_add_filter_arg(query, n, d) \
-                for n, d in zip(['filters'], [query['filters']])]
+            mcf_query = self._service.data().mcf().get(**formatted_query)
             
-        except KeyError:
-            pass
+        except TypeError as e:
+            raise ValueError('Error making query: {0}'.format(e))
         
-        # 4. sorting
-        try:
-            [self._maybe_add_sort_arg(query, n, d) \
-                for n, d in zip(['sort'], [query['sort']])]
+        res = mcf_query.execute()
+        
+        if as_dict:
+            return res
+        
+        else:
+            # re-cast query result (dict) to a pd.DataFrame object
+            rows = len(res['rows'])
+            cols = [col['name'][4:] for col in res['columnHeaders']]
             
-        except KeyError:
-            pass
-        
-        # 5. start_index, max_results
-        try:
-            if query['start_index'] is not None:
-                query['start_index'] = str(query['start_index'])
-            
-        except KeyError:
-            pass
-        
-        try:
-            if query['max_results'] is not None:
-                query['max_results'] = str(query['max_results'])
-            
-        except KeyError:
-            pass
-        
-        # 6. samplingLevel
-        try:
-            if query['samplingLevel'] is not None:
-                query['samplingLevel'] = query['samplingLevel'].upper()
+            try:
+                df = pd.DataFrame(np.array(\
+                        [i.values() for row in res['rows'] for i in row]).reshape(rows, len(cols)),
+                            index=np.arange(rows), columns=cols)
                 
-                if query['samplingLevel'].upper() not in ['DEFAULT', 'FASTER', 'HIGHER_PRECISION']:
-                    query.pop('samplingLevel')
-                    
-                    print 'Invalid value for \'samplingLevel\' specified, using \'DEFAULT\' instead'
-                    
-                    
-        except KeyError:
-            pass
-        
-        # 7. Remove options that should not be there
-        for key in query.keys():
-            if key not in ['ids', 'start_date', 'end_date', 'metrics', \
-                            'dimensions', 'sort', 'filters', 'segment', \
-                            'samplingLevel', 'start_index', 'max_results', \
-                            'output', 'fields', 'userIp', 'quotaUser']:
-                query.pop(key)
-                
-                print 'Removed invalid query parameter \'{0}\''.format(key)
-        
-        # Nothing to do for 'segment' actually as it's too fleixible to
-        # fix into this fix-via-intuition framework, at least I'm not seeing
-        # anything obvious. For now, the user has to get it correct.
-        #
-        # TODO:
-        # Add fixes for:
-        # * fields
-        # * userIp
-        # * quotaUser
-        
-        return query
-
-    def _maybe_add_arg(self, query, field, data, prefix='ga:'):
-        d = len(prefix)
-        if data is not None:
-            if isinstance(data, (pd.compat.string_types, int)):
-                data = [data]
-            data = ','.join(['{0}{1}'.format(prefix, x) if x[:d] != prefix \
-                    else x for x in data])
+            except KeyError:
+                df = pd.DataFrame(columns=cols)
+                pass
             
-            query[field] = data
-            
-    def _maybe_add_sort_arg(self, query, field, data, prefix='ga:'):
-        d = len(prefix)
-        if data is not None:
-            if isinstance(data, (pd.compat.string_types, int)):
-                data = [data]
-                
-            def _prefix(item):
-                if item[0] is '-':
-                    if item[1:(d + 1)] == prefix:
-                        return item
-                        
-                    else:
-                        return prefix.join([item[0], item[1:]])
-                    
-                elif item[:d] != prefix:
-                    return prefix + item
-                
+            # TODO:
+            # A tool to accurtely set the dtype for all columns of df would
+            # be nice, but is probably far more effort than it's worth.
+            # This will get the ball rolling, but the end user is likely
+            # going to be stuck dealing with things on a per-case basis.
+            def my_mapper(x):
+                if x == u'INTEGER':
+                    return int
+                elif x == u'CURRENCY':
+                    return float
+                elif x == u'BOOLEAN':
+                    return bool
                 else:
-                    return item
+                    return unicode
                 
-            data = ','.join([_prefix(x) for x in data])
+            for hdr in res[u'columnHeaders']:
+                col = hdr[u'name'][4:]
+                dtp = hdr[u'dataType']
+                
+                df[col] = df[col].apply(my_mapper(dtp))
+                
+            # Get the summary info returned
+            metadata = res.copy()
+            metadata.pop('rows')
+            metadata.pop('columnHeaders')
             
-            query[field] = data
-            
-    def _maybe_add_filter_arg(self, query, field, data, prefix='ga:'):
-        d = len(prefix)
-        if data is not None:
-            if isinstance(data, (pd.compat.string_types, int)):
-                data = [data]
-                
-            def _prefix(item):
-                if item[:d] != prefix:
-                    return prefix + item
-                
-                else:
-                    return item
-            
-            if len(data) > 1:
-                lookup = {'AND' : ';', 'OR' : ','}
-                
-                args = data[0::2]
-                rules = [rule.upper() for rule in data[1::2]]
-                
-                if (len(set(rules).union(set(lookup.keys()))) > 2) | (len(args) - len(rules) != 1):
-                    raise ValueError('Malformed / invalid filter' )
-                
-                res = ''.join([_prefix(arg) + rule for (arg, rule) in \
-                    zip(args, [lookup[rule] for rule in rules])]) + _prefix(data[-1])
-                
-                query[field] = res
-                
-            else:
-                self._maybe_add_arg(query, field, data, prefix=prefix)
+            return df, metadata

--- a/google2pandas/_panalysis_ga.py
+++ b/google2pandas/_panalysis_ga.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env/python
-
 from __future__ import division
 
 from googleapiclient.discovery import build
@@ -190,8 +188,7 @@ class GoogleAnalyticsQuery(OAuthDataReader):
         Returns:
         -----------
             reuslt : pd.DataFrame or dict
-            query  : a copy of the (formatted) query actually used
-            sampling : summay of sampling data if result contains sampled data
+            metadata : summary data supplied with query result
         '''
         try:
             formatted_query = QueryParser().parse(**query)
@@ -243,12 +240,11 @@ class GoogleAnalyticsQuery(OAuthDataReader):
                 
                 df[col] = df[col].apply(my_mapper(dtp))
                 
-            # Get the summary info returned
-            metadata = res.copy()
-            metadata.pop('rows')
-            metadata.pop('columnHeaders')
-                
-            return df, metadata
+            # Return the summary info as well
+            res.pop('rows')
+            res.pop('columnHeaders')
+            
+            return df, res
         
         
 class GoogleMCFQuery(OAuthDataReader):
@@ -327,8 +323,7 @@ class GoogleMCFQuery(OAuthDataReader):
         Returns:
         -----------
             reuslt : pd.DataFrame or dict
-            query  : a copy of the (formatted) query actually used
-            sampling : summay of sampling data if result contains sampled data
+            metadata : summary data supplied with query result
         '''
         try:
             formatted_query = QueryParser(prefix=u'mcf:').parse(**query)
@@ -378,9 +373,8 @@ class GoogleMCFQuery(OAuthDataReader):
                 
                 df[col] = df[col].apply(my_mapper(dtp))
                 
-            # Get the summary info returned
-            metadata = res.copy()
-            metadata.pop('rows')
-            metadata.pop('columnHeaders')
+            # Return the summary info as well
+            res.pop('rows')
+            res.pop('columnHeaders')
             
-            return df, metadata
+            return df, res

--- a/google2pandas/_query_parser.py
+++ b/google2pandas/_query_parser.py
@@ -1,0 +1,200 @@
+from __future__ import division
+
+import pandas as pd
+
+class QueryParser(object):
+    '''
+    Simple parser to allow users to be a bit sloppy with thier queries and still
+    get what they want.
+    '''
+    def __init__(self, prefix=u'ga:'):
+        self.prefix = prefix
+    
+    def parse(self, **kwargs):
+        '''
+        Check query structure to ensure formatting is valid
+        '''
+        query = {}
+        query.update(kwargs)
+        
+        # 1. Dates
+        # The next two steps keep things consistent if the query is to be archived.
+        try:
+            if query['start_date'][-7:] == 'daysAgo':
+                sd = pd.datetime.today() + \
+                    pd.tseries.offsets.DateOffset(days=-int(query['start_date'][:-7]))
+                query['start_date'] = sd.strftime('%Y-%m-%d')
+                
+            elif query['start_date'] == 'yesterday':
+                sd = pd.datetime.today() + pd.tseries.offsets.DateOffset(days=-1)
+                query['start_date'] = sd.strftime('%Y-%m-%d')
+                
+            elif query['start_date'] == 'today':
+                query['start_date'] = pd.datetime.today().strftime('%Y-%m-%d')
+                
+            else:
+                query['start_date'] = pd.to_datetime(query['start_date'], \
+                    format='%Y-%m-%d').strftime('%Y-%m-%d')
+                
+        except (KeyError, AttributeError) as e:
+            raise ValueError('The (required) \'start_date\' parameter is missing or invalid')
+            
+        try:
+            if (query['end_date'] is None) | (query['end_date'] == 'today'):
+                end_date = pd.datetime.today().strftime('%Y-%m-%d')
+                
+            else:
+                query['end_date'] = pd.to_datetime(query['end_date']).strftime('%Y-%m-%d')
+                
+        except KeyError:
+            query['end_date'] = pd.datetime.today().strftime('%Y-%m-%d')
+        
+        # 2. Prefixing
+        # Ensure that all fields that should be in the form 'prefix:XXXX' acutally are.
+        # Error handling skipped at this location intentionally.
+        #
+        # First sneak in fix to allow providing ids as int value
+        query['ids'] = str(query['ids'])
+        
+        names = 'ids', 'dimensions', 'metrics'
+        lst = query['ids'], query['dimensions'], query['metrics']
+        [self._maybe_add_arg(query, n, d) for n, d in zip(names, lst)]
+        
+        # 3. Clean up the filtering if present
+        try:
+            [self._maybe_add_filter_arg(query, n, d) \
+                for n, d in zip(['filters'], [query['filters']])]
+            
+        except KeyError:
+            pass
+        
+        # 4. sorting
+        try:
+            [self._maybe_add_sort_arg(query, n, d) \
+                for n, d in zip(['sort'], [query['sort']])]
+            
+        except KeyError:
+            pass
+        
+        # 5. start_index, max_results
+        try:
+            if query['start_index'] is not None:
+                query['start_index'] = str(query['start_index'])
+            
+        except KeyError:
+            pass
+        
+        try:
+            if query['max_results'] is not None:
+                query['max_results'] = str(query['max_results'])
+            
+        except KeyError:
+            pass
+        
+        # 6. samplingLevel
+        try:
+            if query['samplingLevel'] is not None:
+                query['samplingLevel'] = query['samplingLevel'].upper()
+                
+                if query['samplingLevel'].upper() not in ['DEFAULT', 'FASTER', 'HIGHER_PRECISION']:
+                    query.pop('samplingLevel')
+                    
+                    print 'Invalid value for \'samplingLevel\' specified, using \'DEFAULT\' instead'
+                    
+                    
+        except KeyError:
+            pass
+        
+        # 7. Remove options that should not be there
+        for key in query.keys():
+            if key not in ['ids', 'start_date', 'end_date', 'metrics', \
+                            'dimensions', 'sort', 'filters', 'segment', \
+                            'samplingLevel', 'start_index', 'max_results', \
+                            'output', 'fields', 'userIp', 'quotaUser']:
+                query.pop(key)
+                
+                print 'Removed invalid query parameter \'{0}\''.format(key)
+        
+        # Nothing to do for 'segment' actually as it's too fleixible to
+        # fix into this fix-via-intuition framework, at least I'm not seeing
+        # anything obvious. For now, the user has to get it correct.
+        #
+        # TODO:
+        # Add fixes for:
+        # * fields
+        # * userIp
+        # * quotaUser
+        
+        return query
+
+    def _maybe_add_arg(self, query, field, data):
+        d = len(self.prefix)
+        
+        # Kludge to account for the fact that the same (GA) ids value is used
+        # for different google products.
+        if field == 'ids':
+            prefix = 'ga:'
+        else:
+            prefix = self.prefix
+            
+        if data is not None:
+            if isinstance(data, (pd.compat.string_types, int)):
+                data = [data]
+            data = ','.join(['{0}{1}'.format(prefix, x) if x[:d] != prefix \
+                    else x for x in data])
+            
+            query[field] = data
+            
+    def _maybe_add_sort_arg(self, query, field, data):
+        d = len(self.prefix)
+        if data is not None:
+            if isinstance(data, (pd.compat.string_types, int)):
+                data = [data]
+                
+            def _prefix(item):
+                if item[0] is '-':
+                    if item[1:(d + 1)] == self.prefix:
+                        return item
+                        
+                    else:
+                        return self.prefix.join([item[0], item[1:]])
+                    
+                elif item[:d] != self.prefix:
+                    return self.prefix + item
+                
+                else:
+                    return item
+                
+            data = ','.join([_prefix(x) for x in data])
+            
+            query[field] = data
+            
+    def _maybe_add_filter_arg(self, query, field, data):
+        d = len(self.prefix)
+        if data is not None:
+            if isinstance(data, (pd.compat.string_types, int)):
+                data = [data]
+                
+            def _prefix(item):
+                if item[:d] != self.prefix:
+                    return self.prefix + item
+                
+                else:
+                    return item
+            
+            if len(data) > 1:
+                lookup = {'AND' : ';', 'OR' : ','}
+                
+                args = data[0::2]
+                rules = [rule.upper() for rule in data[1::2]]
+                
+                if (len(set(rules).union(set(lookup.keys()))) > 2) | (len(args) - len(rules) != 1):
+                    raise ValueError('Malformed / invalid filter' )
+                
+                res = ''.join([_prefix(arg) + rule for (arg, rule) in \
+                    zip(args, [lookup[rule] for rule in rules])]) + _prefix(data[-1])
+                
+                query[field] = res
+                
+            else:
+                self._maybe_add_arg(query, field, data)


### PR DESCRIPTION
Added an additional class `GoogleMCFQuery` to enable queries to Google's Multi-Channel Funnels Reporting API.

This has led to moving the query-formatting tool to it's own class, as well as making the `_init_service` method part of `OAuthDataReader` (seemed sensible to me).

The main difference from a user point of view is that the `.execute_query` method no longer returns a `pandas.DataFrame` object and a copy of the query sent, but instead the `pandas.DataFrame` object and a dict object `metadata` which is really just the dictionary object returned by Google with the `rows` and `columnHeaders` items removed.

As well, the `provide_json` keyword argument has been renamed to the more sensible `as_dict` instead.

As this is alpha software, no deprication warnings have been provided.
